### PR TITLE
`KashiPair` => `KashiPairMediumRiskV1`

### DIFF
--- a/contracts/KashiPair.sol
+++ b/contracts/KashiPair.sol
@@ -33,7 +33,7 @@ import "./interfaces/ISwapper.sol";
 /// @title KashiPair
 /// @dev This contract allows contract calls to any contract (except BentoBox)
 /// from arbitrary callers thus, don't trust calls from this contract in any circumstances.
-contract KashiPair is ERC20, BoringOwnable, IMasterContract {
+contract KashiPairMediumRiskV1 is ERC20, BoringOwnable, IMasterContract {
     using BoringMath for uint256;
     using BoringMath128 for uint128;
     using RebaseLibrary for Rebase;
@@ -52,7 +52,7 @@ contract KashiPair is ERC20, BoringOwnable, IMasterContract {
 
     // Immutables (for MasterContract and all clones)
     IBentoBoxV1 public immutable bentoBox;
-    KashiPair public immutable masterContract;
+    KashiPairMediumRiskV1 public immutable masterContract;
 
     // MasterContract variables
     address public feeTo;
@@ -652,7 +652,7 @@ contract KashiPair is ERC20, BoringOwnable, IMasterContract {
 
     /// @notice Handles the liquidation of users' balances, once the users' amount of collateral is too low.
     /// @param users An array of user addresses.
-    /// @param maxBorrowParts A one-to-one mapping to `users`, contains maximum (partial) borrow amounts (to liquidate) of the respective user.
+    /// @param maxBorrowParts A one-to-one mapping to `users`, contains partial borrow amounts (to liquidate) of the respective user.
     /// @param to Address of the receiver in open liquidations if `swapper` is zero.
     /// @param swapper Contract address of the `ISwapper` implementation. Swappers are restricted for closed liquidations. See `setSwapper`.
     /// @param open True to perform a open liquidation else False.

--- a/contracts/KashiPairHelper.sol
+++ b/contracts/KashiPairHelper.sol
@@ -3,18 +3,25 @@ pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringMath.sol";
 import "@boringcrypto/boring-solidity/contracts/libraries/BoringRebase.sol";
+import "@boringcrypto/boring-solidity/contracts/libraries/BoringERC20.sol";
 import "@sushiswap/bentobox-sdk/contracts/IBentoBoxV1.sol";
+import "./interfaces/IOracle.sol";
 import "./KashiPair.sol";
 
 /// @dev This contract provides useful helper functions for `KashiPair`.
 contract KashiPairHelper {
     using BoringMath for uint256;
     using BoringMath128 for uint128;
+    using BoringERC20 for IERC20;
     using RebaseLibrary for Rebase;
+
+    uint256 public constant APY_PRECISION = 1e8;
+    uint256 private constant PROTOCOL_FEE_LEFTOVER = 90000; // 100% - 10%
+    uint256 private constant PROTOCOL_FEE_DIVISOR = 1e5;
 
     /// @dev Helper function to calculate the collateral shares that are needed for `borrowPart`,
     /// taking the current exchange rate into account.
-    function getCollateralSharesForBorrowPart(KashiPair kashiPair, uint256 borrowPart) public view returns (uint256) {
+    function getCollateralSharesForBorrowPart(KashiPairMediumRiskV1 kashiPair, uint256 borrowPart) public view returns (uint256) {
         // Taken from KashiPair
         uint256 EXCHANGE_RATE_PRECISION = 1e18;
         uint256 LIQUIDATION_MULTIPLIER = 112000; // add 12%
@@ -32,4 +39,97 @@ contract KashiPairHelper {
                 false
             );
     }
+
+    struct KashiPairInfo {
+        IERC20 collateral;
+        string collateralSymbol;
+        uint8 collateralDecimals;
+        IERC20 asset;
+        string assetSymbol;
+        uint8 assetDecimals;
+        IOracle oracle;
+        bytes oracleData;
+    }
+
+    function getPairs(KashiPairMediumRiskV1[] calldata addresses) public view returns (KashiPairInfo[] memory) {
+        KashiPairInfo[] memory pairs = new KashiPairInfo[](addresses.length);
+        for (uint256 i = 0; i < addresses.length; i++) {
+            pairs[i].collateral = addresses[i].collateral();
+            pairs[i].collateralSymbol = IERC20(addresses[i].collateral()).safeSymbol();
+            pairs[i].collateralDecimals = IERC20(addresses[i].collateral()).safeDecimals();
+            pairs[i].asset = addresses[i].asset();
+            pairs[i].assetSymbol = IERC20(addresses[i].asset()).safeSymbol();
+            pairs[i].assetDecimals = IERC20(addresses[i].asset()).safeDecimals();
+            pairs[i].oracle = addresses[i].oracle();
+            pairs[i].oracleData = addresses[i].oracleData();
+        }
+        return pairs;
+    }
+
+    struct PairPollInfo {
+        uint256 suppliedPairCount;
+        uint256 borrowPairCount;
+    }
+
+    struct PairPoll {
+        uint256 totalCollateralAmount;
+        uint256 userCollateralAmount;
+        uint256 totalAssetAmount;
+        uint256 userAssetAmount;
+        uint256 totalBorrowAmount;
+        uint256 userBorrowAmount;
+        uint256 currentExchangeRate;
+        uint256 oracleExchangeRate;
+        uint64 interestPerSecond;
+        uint256 assetAPR;
+        uint256 borrowAPR;
+    }
+
+    function pollPairs(address who, KashiPairMediumRiskV1[] calldata addresses) public view returns (PairPollInfo memory, PairPoll[] memory) {
+        PairPollInfo memory info;
+        PairPoll[] memory pairs = new PairPoll[](addresses.length);
+
+        for (uint256 i = 0; i < addresses.length; i++) {
+            IBentoBoxV1 bentoBox = IBentoBoxV1(addresses[i].bentoBox());
+            {
+                pairs[i].totalCollateralAmount = bentoBox.toAmount(addresses[i].collateral(), addresses[i].totalCollateralShare(), false);
+                pairs[i].userCollateralAmount = bentoBox.toAmount(addresses[i].collateral(), addresses[i].userCollateralShare(who), false);
+            }
+            {
+                Rebase memory totalAsset;
+                {
+                    (uint128 totalAssetElastic, uint128 totalAssetBase) = addresses[i].totalAsset();
+                    pairs[i].totalAssetAmount = bentoBox.toAmount(addresses[i].asset(), totalAssetElastic, false);
+                    totalAsset = Rebase(totalAssetElastic, totalAssetBase);
+                }
+                pairs[i].userAssetAmount = bentoBox.toAmount(addresses[i].asset(), totalAsset.toElastic(addresses[i].balanceOf(who), false), false);
+                if(pairs[i].userAssetAmount > 0) {
+                    info.suppliedPairCount += 1;
+                }
+            }
+            {
+                {
+                    pairs[i].currentExchangeRate = addresses[i].exchangeRate();
+                    (, pairs[i].oracleExchangeRate) = addresses[i].oracle().peek(addresses[i].oracleData());
+                    (pairs[i].interestPerSecond, ,) = addresses[i].accrueInfo();
+                }
+                (uint128 totalBorrowAmount, uint128 totalBorrowPart) = addresses[i].totalBorrow();
+                Rebase memory totalBorrow = Rebase(totalBorrowAmount, totalBorrowPart);
+                pairs[i].totalBorrowAmount = totalBorrowAmount;
+                pairs[i].userBorrowAmount = totalBorrow.toElastic(addresses[i].userBorrowPart(who), false);
+                if(pairs[i].userBorrowAmount > 0) {
+                    info.borrowPairCount += 1;
+                }
+            }
+            {
+                uint256 yearlyInterest = pairs[i].totalBorrowAmount.mul(pairs[i].interestPerSecond).mul(365 days) / 1e18;
+                pairs[i].assetAPR = yearlyInterest.mul(APY_PRECISION).mul(PROTOCOL_FEE_LEFTOVER) / pairs[i].totalBorrowAmount.add(pairs[i].totalAssetAmount).mul(PROTOCOL_FEE_DIVISOR);
+                pairs[i].borrowAPR = yearlyInterest.mul(APY_PRECISION) / pairs[i].totalBorrowAmount;
+            }
+        }
+
+        return (info, pairs);
+
+    }
+
 }


### PR DESCRIPTION
change contract name from `KashiPair` to `KashiPairMediumRiskV1` to match deployment to [0x009e9cFaD18132D9fB258984196191BdB6D58CFF](https://ropsten.etherscan.io/address/0x009e9cfad18132d9fb258984196191bdb6d58cff#code) & format in [flat file](https://github.com/sushiswap/kashi-lending/blob/master/contracts/flat/KashiPairFlat.sol).