### PR TITLE
IKashiPair.sol accrueInfo return values updated to match with KashiPair.sol 

### DIFF
--- a/contracts/interfaces/IKashiPair.sol
+++ b/contracts/interfaces/IKashiPair.sol
@@ -30,8 +30,8 @@ interface IKashiPair {
         external
         view
         returns (
-            uint64 interestPerBlock,
-            uint64 lastBlockAccrued,
+            uint64 interestPerSecond,
+            uint64 lastAccrued,
             uint128 feesEarnedFraction
         );
 


### PR DESCRIPTION
`IKashiPair.sol` exposes value names suggesting block related units of interest

    function accrueInfo()        
        external        
        view        
        returns (           
            uint64 interestPerBlock,            
            uint64 lastBlockAccrued,           
            uint128 feesEarnedFraction        
        );

opposed to `KashiPair.sol` and `BoringHelperFlat.sol` having time (s) related  units

    struct AccrueInfo(          
            uint64 interestPerSecond,            
            uint64 lastAccrued,           
            uint128 feesEarnedFraction        
    );